### PR TITLE
Fix URLs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ See TreeLib.BreadthFirst.Traverse.Postorder implementation for:
 * <a href="https://github.com/Dirkster99/TreeLib/blob/master/source/Shared/Depthfirst/PostOrder.cs">Generic Post-Order</a> function and <a href="https://github.com/Dirkster99/TreeLib/blob/master/source/TreeLibNugetDemo/Program.cs">DemoDirectoryTreeTraversal</a>
 
 # Tip
-* Read about <a href="http://www.codeducky.org/easy-tree-and-linked-list-traversal-in-c/">Generic Tree and Linked List Traversal in C#</a> to understand the usefulness of *Generic* traversal methods.
+* Read about [Generic Tree and Linked List Traversal in C#](http://web.archive.org/web/20180128233111/http://www.codeducky.org/easy-tree-and-linked-list-traversal-in-c/) to understand the usefulness of *Generic* traversal methods.
 
 * Watch the <a href="https://www.youtube.com/watch?v=gm8DUJJhmY4">Binary tree traversal: Preorder, Inorder, Postorder</a> video to better understand what is what (and why these Traversal Order Names make some sense):
 
-* Look into data structure books online ![Introduction to Trees, Binary Search Trees](https://cathyatseneca.gitbooks.io/data-structures-and-algorithms/introduction_to_trees,_binary_search_trees/definitions.html) or offline *![Algorithms](http://algs4.cs.princeton.edu/home/)* by Robert Sedgewick and Kevin Wayne, if you still need more background on tree structures 
+* Look into data structure books online [Introduction to Trees, Binary Search Trees](https://cathyatseneca.gitbooks.io/data-structures-and-algorithms/introduction_to_trees,_binary_search_trees/definitions.html) or offline *[Algorithms](http://algs4.cs.princeton.edu/home/)* by Robert Sedgewick and Kevin Wayne, if you still need more background on tree structures 


### PR DESCRIPTION
- URLs formatted as images instead of links.
- `Generic Tree and Linked List Traversal in C#` link was broken, added `WebArchive` link